### PR TITLE
fallback for empty post titles + optimised readability in header.html + footer.html

### DIFF
--- a/block-template-parts/footer.html
+++ b/block-template-parts/footer.html
@@ -3,7 +3,11 @@
 <!-- /wp:spacer -->
 
 <!-- wp:group {"align":"full","backgroundColor":"dark","textColor":"light","style":{"color":{"link":"var:preset|color|light"}}} -->
-<div class="wp-block-group alignfull has-light-color has-dark-background-color has-text-color has-background has-link-color" style="--wp--style--color--link:var(--wp--preset--color--light)"><div class="wp-block-group__inner-container"><!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Site proudly powered by <a href="https://wordpress.org" target="_blank" rel="noreferrer noopener">WordPress</a>, using the <a href="https://github.com/aristath/q" target="_blank" rel="noreferrer noopener">Q theme</a>.</p>
-<!-- /wp:paragraph --></div></div>
+<div class="wp-block-group alignfull has-light-color has-dark-background-color has-text-color has-background has-link-color" style="--wp--style--color--link:var(--wp--preset--color--light)">
+    <div class="wp-block-group__inner-container">
+        <!-- wp:paragraph {"align":"center"} -->
+        <p class="has-text-align-center">Site proudly powered by <a href="https://wordpress.org" target="_blank" rel="noreferrer noopener">WordPress</a>, using the <a href="https://github.com/aristath/q" target="_blank" rel="noreferrer noopener">Q theme</a>.</p>
+        <!-- /wp:paragraph -->
+    </div>
+</div>
 <!-- /wp:group -->

--- a/block-template-parts/header.html
+++ b/block-template-parts/header.html
@@ -1,11 +1,11 @@
 <!-- wp:group -->
-<div class="wp-block-group"><div class="wp-block-group__inner-container"><!-- wp:site-title {"textAlign":"center"} /-->
-
-<!-- wp:navigation {"itemsJustification":"center", "orientation":"horizontal"} -->
-<!-- wp:navigation-link {"label":"Home","url":"/"} /-->
-
-<!-- wp:navigation-link {"label":"About","url":"/about"} /-->
-
-<!-- wp:navigation-link {"label":"Blog","url":"/blog"} /-->
-<!-- /wp:navigation --></div></div>
+<div class="wp-block-group">
+    <div class="wp-block-group__inner-container"><!-- wp:site-title {"textAlign":"center"} /-->
+        <!-- wp:navigation {"itemsJustification":"center", "orientation":"horizontal"} -->
+            <!-- wp:navigation-link {"label":"Home","url":"/"} /-->
+            <!-- wp:navigation-link {"label":"About","url":"/about"} /-->
+            <!-- wp:navigation-link {"label":"Blog","url":"/blog"} /-->
+        <!-- /wp:navigation -->
+    </div>
+</div>
 <!-- /wp:group -->

--- a/functions.php
+++ b/functions.php
@@ -69,3 +69,14 @@ new \QTheme\BlockStyles();
 // Add scripts.
 require_once 'includes/Scripts.php';
 new \QTheme\Scripts();
+
+
+/**
+ * Show '(no title)' in frontend if post has no title to make it selectable
+ */
+add_filter( 'the_title', function($title){
+	if (! is_admin() && empty( $title )) {
+		$title = __( '(no title)' );
+    }
+    return $title;
+});

--- a/functions.php
+++ b/functions.php
@@ -65,7 +65,7 @@ add_filter(
 	'the_title',
 	function( $title ) {
 		if ( ! is_admin() && empty( $title ) ) {
-			$title = __( '(no title)' , 'q');
+			$title = __( '(no title)', 'q' );
 		}
 
 		return $title;

--- a/functions.php
+++ b/functions.php
@@ -61,12 +61,16 @@ add_filter(
 /**
  * Show '(no title)' in frontend if post has no title to make it selectable
  */
-add_filter( 'the_title', function($title){
-	if (! is_admin() && empty( $title )) {
-		$title = __( '(no title)' );
-    }
-    return $title;
-});
+add_filter(
+	'the_title',
+	function( $title ) {
+		if ( ! is_admin() && empty( $title ) ) {
+			$title = __( '(no title)' , 'q');
+		}
+
+		return $title;
+	}
+);
 
 // Add global styles.
 require_once 'includes/Styles.php';

--- a/functions.php
+++ b/functions.php
@@ -58,6 +58,16 @@ add_filter(
 	}
 );
 
+/**
+ * Show '(no title)' in frontend if post has no title to make it selectable
+ */
+add_filter( 'the_title', function($title){
+	if (! is_admin() && empty( $title )) {
+		$title = __( '(no title)' );
+    }
+    return $title;
+});
+
 // Add global styles.
 require_once 'includes/Styles.php';
 new \QTheme\Styles();
@@ -69,14 +79,3 @@ new \QTheme\BlockStyles();
 // Add scripts.
 require_once 'includes/Scripts.php';
 new \QTheme\Scripts();
-
-
-/**
- * Show '(no title)' in frontend if post has no title to make it selectable
- */
-add_filter( 'the_title', function($title){
-	if (! is_admin() && empty( $title )) {
-		$title = __( '(no title)' );
-    }
-    return $title;
-});


### PR DESCRIPTION
## Description
At the moment in archives you can't select posts without titles.
- In https://github.com/aristath/q/issues/2 @carolinan gave the hint that `the_title` filter may be usable for this approach.
- I sticked to the behaviour of `_draft_or_post_title()` ([See Codex](https://developer.wordpress.org/reference/functions/_draft_or_post_title/)) to render the phrase `(no title`) in different languages. EDIT: Because of linter errors I had to add a textdomain for the string, therefore, it's not automatically translated anymore - unfortunately.
- I placed an anonymous function in `functions.php` to make the code changes as small as possible. I positioned it before the Styles- and Script-Classes to match the current structure.

## Alternatives
TwentySeventeen, TwentyNineteen and TwentyTwenty don't show the title. Instead the post's date is clickable.

![image](https://user-images.githubusercontent.com/26542182/95675024-7df29200-0bb4-11eb-99c8-5dec12a05253.jpeg)

I considered using `render_block` filter to add the permalink to the date, but it seems that the filter doesn't work inside `the_loop` as it always uses the permalink of the first item in loop. (Furthermore, the theme's styling currently breaks.)

![image](https://user-images.githubusercontent.com/26542182/95675268-3a992300-0bb6-11eb-95f2-f4a1d66f5a6a.jpeg)


Code for testing the behaviour above (rendered `the_permalink` additionaly after the date for testing purposes):

```php
/**
 * Add permalink to post date
 */

add_filter( 'render_block', function($block_content, $block){
	if ( $block['blockName'] === 'core/post-date' ) {
        return '<a href="' . get_the_permalink() . '">' . $block_content . ' ' . get_the_permalink() . '</a>';
    }
    return $block_content;
}, 10, 2 );
```

## Additionals
I optimised the structure of `footer.html` and `header.html` to make it more readable.